### PR TITLE
ISSUE-7 - Hotfix of issue-7 from upstream repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**Note**
+This repository is forked from maxecloo/Docker cause of trouble using nginx-php on Mac OS with boot2docker.
+It contains a fix were the php-fpm.sock file is not stored in the data volumne container, it's now placed into /run directory of the docker container.
+
 **Description**  
 This repository contains a collection of Docker configurations I've put together to meet my needs.
 

--- a/frameworks/nginx-php/etc/nginx/addon.d/default-php.conf
+++ b/frameworks/nginx-php/etc/nginx/addon.d/default-php.conf
@@ -2,7 +2,7 @@ client_max_body_size 256m;
 index index.html index.php;
 location ~ \.php$ {
 	fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-	fastcgi_pass unix:/data/secure/php5-fpm.sock;
+	fastcgi_pass unix:/run/php5-fpm.sock;
 	fastcgi_index index.php;
 	fastcgi_split_path_info ^(.+\.php)(.*)$;
 	include fastcgi_params;

--- a/frameworks/nginx-php/etc/php5/fpm/pool.d/default.conf
+++ b/frameworks/nginx-php/etc/php5/fpm/pool.d/default.conf
@@ -1,7 +1,7 @@
 [default]
 user = core
 group = core
-listen = /data/secure/php5-fpm.sock
+listen = /run/php5-fpm.sock
 listen.owner = core
 pm = ondemand
 pm.max_children = 4


### PR DESCRIPTION
Fix for Mac OS users using boot2docker and nginx-php. The sock file was stored into the data volume container and a mount of it using the host-system results a crash of the php-fpm service, cause sock file cannot written (Php Exit Code 78).
This merge-request moves the sock-file into the /run directory of the container.
Please note, I only fixed it for the nginx-php configuration, I do not know if there could be a problem on other Dockerfiles inside the repo.
