### PR TITLE
Updating debian/ubuntu dockerfiles so that the base images are smaller.

### DIFF
--- a/base/debian/Dockerfile
+++ b/base/debian/Dockerfile
@@ -2,10 +2,10 @@ FROM debian:latest
 MAINTAINER Max Schaefer <max@excloo.com>
 ADD etc /etc
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y ca-certificates inotify-tools nano pwgen supervisor unrar unzip wget
-RUN apt-get clean
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y ca-certificates inotify-tools nano pwgen supervisor unrar unzip wget \
+  && apt-get clean
 RUN mkdir /config /data
 RUN useradd -u 500 core
 ADD config /config

--- a/base/ubuntu/Dockerfile
+++ b/base/ubuntu/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:latest
 MAINTAINER Max Schaefer <max@excloo.com>
 ADD etc /etc
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y ca-certificates inotify-tools nano pwgen supervisor unrar unzip wget
-RUN apt-get clean
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y ca-certificates inotify-tools nano pwgen supervisor unrar unzip wget \
+  && apt-get clean
 RUN mkdir /config /data
 RUN useradd -u 500 core
 ADD config /config


### PR DESCRIPTION
With docker every new command (RUN, ADD, etc) generate a new image. So running apt-get update in one RUN and running apt-get clean in another doesn't make your final image size any smaller. Running them all in one RUN command though will result in the disk image being created without the apt cache data in the image anywhere.
