### PR TITLE
Fix /data/config typo in README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains a collection of Docker configurations I've put together
     Nginx based frameworks have a simple directory structure that can be used to easily deploy web applications using a volume on /data.
 
         /data
-            /conf
+            /config
                 nginx-*.conf // included by nginx
                 php-*.conf // included by php5-fpm
             /http


### PR DESCRIPTION
Hi, I've been using `maxexcloo/nginx-php` and noticed that `/data/conf` mentioned in documentation didn't exist, from what I can see it should say `/data/config` instead, so here's a PR.