### PR TITLE
Fixed #23 - [mariadb] Set /data as base folder for mysql logs. Fixed default EN…

### DIFF
--- a/services/mariadb/Dockerfile
+++ b/services/mariadb/Dockerfile
@@ -1,7 +1,9 @@
 FROM maxexcloo/debian:latest
 MAINTAINER Max Schaefer <max@excloo.com>
-ENV MARIADB_USER docker \
-	MARIADB_PASS docker
+
+ENV MARIADB_USER=docker
+ENV MARIADB_PASS=docker
+
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CBCB082A1BB943DB && \
 	echo "deb http://ftp.osuosl.org/pub/mariadb/repo/10.1/debian/ jessie main" > /etc/apt/sources.list.d/mariadb.list && \
 	apt-get update && \
@@ -11,7 +13,12 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CBCB082A1BB943DB &&
 	rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 RUN sed -i -e "s/^bind-address/#bind-address/" /etc/mysql/my.cnf && \
 	sed -i -e "s/^datadir.*=.*/datadir = \/data/" /etc/mysql/my.cnf && \
-	sed -i -e "s/^user.*=.*/user = core/" /etc/mysql/my.cnf
+	sed -i -e "s/^user.*=.*/user = core/" /etc/mysql/my.cnf && \
+	sed -i -e "s/\/var\/log\/mysql/\/data\/log/" /etc/mysql/my.cnf && \
+	chown -R core:adm /var/log/mysql.err && \
+	chown -R core:adm /var/log/mysql.log && \
+	chown -R core:adm /var/log/mysql && \
+	chown -R core:root /run/mysqld
 ADD config /config
 ADD supervisord.conf /etc/supervisor/conf.d/mariadb.conf
 EXPOSE 3306

--- a/services/mariadb/config/init/mariadb
+++ b/services/mariadb/config/init/mariadb
@@ -1,9 +1,16 @@
-if [ ! "$(ls -A /data)" ]; then
+if [ ! "$(ls -A /data/aria_log_control)" ]; then
+	mkdir -p /data/log
+	chown -R core:core /data/log
 	mysql_install_db --datadir=/data --user=core
 	mysqld_safe --skip-grant-tables &
 	while [ ! -e /run/mysqld/mysqld.sock ]; do
 		inotifywait -e create -q /run/mysqld/
 	done
-	mysql -u root -e "FLUSH PRIVILEGES; CREATE USER '$MARIADB_USER'@'%' IDENTIFIED BY '$MARIADB_PASS'; GRANT ALL PRIVILEGES ON *.* TO '$MARIADB_USER'@'%' WITH GRANT OPTION;"
+	mysql -u root -e "FLUSH PRIVILEGES; CREATE USER '${MARIADB_USER}'@'%' IDENTIFIED BY '${MARIADB_PASS}'; GRANT ALL PRIVILEGES ON *.* TO '${MARIADB_USER}'@'%' WITH GRANT OPTION;"
+	mysql -u root -e "CREATE DATABASE IF NOT EXISTS ${MARIADB_USER};"
 	mysqladmin -u root shutdown
 fi
+
+# Make socket writable for core
+chown -R core:root /run/mysqld
+chown -R core:core /data/log


### PR DESCRIPTION
- Set `/data` as base folder for every mysql logs, fixing initial startup issue.  
- `chown` mysql socket (`/run/mysql`) which prevented mysql daemon to listen requests.
- Fixed default ENV vars syntax in Dockerfile. 
- Create a default database named after user.