### PR TITLE
Install `php-mbstring` package

### DIFF
--- a/frameworks/nginx-php/Dockerfile
+++ b/frameworks/nginx-php/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Max Schaefer <max@excloo.com>
 RUN curl https://www.dotdeb.org/dotdeb.gpg | apt-key add - && \
 	echo "deb http://packages.dotdeb.org/ jessie all" > /etc/apt/sources.list.d/dotdeb.list && \
 	apt-get update && \
-	apt-get install -y php-cli php-curl php-fpm php-gd php-mcrypt php-mysql php-pgsql php-sqlite3 && \
+	apt-get install -y php-cli php-curl php-fpm php-gd php-mbstring php-mcrypt php-mysql php-pgsql php-sqlite3 && \
 	apt-get clean && \
 	echo -n > /var/lib/apt/extended_states && \
 	rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*


### PR DESCRIPTION
`phpmyadmin` requires `mbstring` and `maxexcloo/phpmyadmin` image fails silently without it.